### PR TITLE
Add requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,5 @@
+bmp280==0.0.4
+picamera==1.13
+pyserial==3.5
+smbus==1.1.post2
+smbus2==0.4.1


### PR DESCRIPTION
Added requirements.txt.
It contains information about required python packages.

To install required packages, run
> pip install -r requirements.txt

To save required packages for all python scripts contained in a directory, install "pipreqs" using
> pip install pipreqs
and run:
> pipreqs [dir] -f
to update the requirements.txt in the specified directory (defaults to current directory)